### PR TITLE
refactor: centralize cover retrieval in library

### DIFF
--- a/Assets/js/Library.js
+++ b/Assets/js/Library.js
@@ -1,8 +1,24 @@
 (() => {
   if (window.Library) return;     // защита от двойной загрузки
   const DEBUG = !!window.__DEBUG__;
-  console.log('[Library] v1.0.1');
+  console.log('[Library] v1.1.0');
   const log   = (...a) => DEBUG && console.log('[Library]', ...a);
+
+  const coverURL = () => {
+    const imgMini = document.querySelector('div[data-test-id="PLAYERBAR_DESKTOP_COVER_CONTAINER"] img');
+    if (imgMini?.src) return imgMini.src;
+
+    const imgFull = document.querySelector('[data-test-id="FULLSCREEN_PLAYER_MODAL"] img[data-test-id="ENTITY_COVER_IMAGE"]');
+    if (imgFull?.src) return imgFull.src;
+
+    const any = document.querySelector('img[data-test-id="ENTITY_COVER_IMAGE"]');
+    return any?.src || null;
+  };
+
+  const getHiResCover = () => {
+    const img = document.querySelector('[class*="PlayerBarDesktopWithBackgroundProgressBar_cover"] img');
+    return img?.src?.includes('/100x100') ? img.src.replace('/100x100', '/1000x1000') : null;
+  };
 
   /* ════════════════════════════════════════════════════════════════════════════════════
    *  EventEmitter
@@ -317,12 +333,12 @@ class PlayerEvents extends EventEmitter {
     if (this.state?.track?.title) return this.state.track;
 
     try {
-      const img = document.querySelector('[class*="PlayerBarDesktop_cover"] img');
+      const src = coverURL();
       const titleEl = document.querySelector('[class*="TrackInfo_title"]');
       const artistEls = [...document.querySelectorAll('[class*="TrackInfo_artists"] a')];
 
       return {
-        coverUri: img?.src?.split('https://')[1]?.replace('100x100', '%%') || '',
+        coverUri: src?.split('https://')[1]?.replace('100x100', '%%') || '',
         title: titleEl?.textContent || '',
         artists: artistEls.map(a => ({ name: a.textContent }))
       };
@@ -569,6 +585,6 @@ class SpotifyScreen {
    *  Export
    * ══════════════════════════════════════════════════════════════════════════════════ */
   window.Theme = Theme;
-  window.Library = { EventEmitter, StylesManager, SettingsManager, UI, PlayerEvents, Theme, SpotifyScreen };
+  window.Library = { EventEmitter, StylesManager, SettingsManager, UI, PlayerEvents, Theme, SpotifyScreen, coverURL, getHiResCover };
   console.log('Library loaded ✓');
 })();

--- a/Assets/js/colorize 2.js
+++ b/Assets/js/colorize 2.js
@@ -55,20 +55,7 @@
   };
 
   /*──────────────────────── cover helpers ───────────────────*/
-  const coverURL = () => {
-    const imgMini = document.querySelector(
-      'div[data-test-id="PLAYERBAR_DESKTOP_COVER_CONTAINER"] img'
-    );
-    if (imgMini?.src) return imgMini.src;
-
-    const imgFull = document.querySelector(
-      '[data-test-id="FULLSCREEN_PLAYER_MODAL"] img[data-test-id="ENTITY_COVER_IMAGE"]'
-    );
-    if (imgFull?.src) return imgFull.src;
-
-    const any = document.querySelector('img[data-test-id="ENTITY_COVER_IMAGE"]');
-    return any?.src || null;
-  };
+  const coverURL = () => window.Library?.coverURL?.() || null;
 
   const CANVAS = document.createElement('canvas');
   CANVAS.width = CANVAS.height = 64;
@@ -329,13 +316,7 @@ let lastAvatarZoom = null;
 let lastBackgroundURL = '';
 let lastPageURL = location.href;
 
-async function getHiResCover() {
-  const img = document.querySelector('[class*="PlayerBarDesktopWithBackgroundProgressBar_cover"] img');
-  if (img && img.src.includes('/100x100')) {
-    return img.src.replace('/100x100', '/1000x1000');
-  }
-  return null;
-}
+const getHiResCover = () => window.Library?.getHiResCover?.() || null;
 
 function backgroundReplace(imageURL) {
   const target = document.querySelector('[class*="MainPage_vibe"]');


### PR DESCRIPTION
## Summary
- expose `coverURL` and `getHiResCover` helpers from Library
- reuse library cover helpers inside PlayerEvents
- simplify Colorize 2 to use shared cover helpers

## Testing
- `node --check Assets/js/Library.js`
- `node --check Assets/js/'colorize 2.js'`


------
https://chatgpt.com/codex/tasks/task_e_68924c93777c8333babaa6f89216511d