### PR TITLE
feat: display track cover in SpotifyScreen

### DIFF
--- a/Assets/css/SpotifyScreen.css
+++ b/Assets/css/SpotifyScreen.css
@@ -29,12 +29,21 @@
 }
 
 .SM_Cover {
-	width: 250px;
-	height: 250px;
-	border-radius: 10px;
-	margin: 25px auto;
-	margin-top: 18px;
-	z-index: var(--ym-z-index-player);
+        width: 250px;
+        height: 250px;
+        border-radius: 10px;
+        margin: 25px auto;
+        margin-top: 18px;
+        z-index: var(--ym-z-index-player);
+        overflow: hidden;
+        position: relative;
+}
+
+.SM_Cover img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
 }
 
 .SM_Decorate_AddToPlaylist_Button {

--- a/Assets/js/Library.js
+++ b/Assets/js/Library.js
@@ -483,7 +483,21 @@ class SpotifyScreen {
       ? `https://${t.coverUri.replace('%%', '1000x1000')}`
       : 'https://raw.githubusercontent.com/Imperiadicks/SpotCol-Scripts/main/Assets/no-cover.png';
 
-    [this.#bg, this.#cover].forEach(n => n.style.background = `url(${img}) center/cover no-repeat`);
+    this.#bg.style.background = `url(${img}) center/cover no-repeat`;
+
+    let tag = this.#cover.querySelector('img');
+    if (!tag) {
+      tag = document.createElement('img');
+      tag.alt = '';
+      tag.style.cssText = `
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      `;
+      this.#cover.appendChild(tag);
+    }
+    tag.src = img;
     this.#track.textContent  = t.title || '';
     this.#artist.textContent = (t.artists || []).map(a => a.name).join(', ');
     this.#syncState();

--- a/Assets/js/SpotifyScreen.js
+++ b/Assets/js/SpotifyScreen.js
@@ -151,22 +151,19 @@ function setCoverImage(coverUri) {
   const container = document.querySelector('.SM_Cover');
   if (!container) return;
 
-  const old = container.querySelectorAll('.bg-layer');
-  old.forEach(el => el.remove());
-
-  const layer = document.createElement('div');
-  layer.className = 'bg-layer';
-  layer.style.cssText = `
-    position: absolute;
-    inset: 0;
-    background: url("${url}") center/cover no-repeat;
-    z-index: -1;
-    opacity: 1;
-    transition: opacity 0.6s ease;
-  `;
-
-  container.style.position = 'relative';
-  container.appendChild(layer);
+  let img = container.querySelector('img');
+  if (!img) {
+    img = document.createElement('img');
+    img.alt = '';
+    img.style.cssText = `
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    `;
+    container.appendChild(img);
+  }
+  img.src = url;
 }
 
 const update = (state) => {


### PR DESCRIPTION
## Summary
- show current track cover inside SM_Cover
- style cover container and image
- update library SpotifyScreen to use embedded image

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689250d89120833384b009dd42834d7e